### PR TITLE
[H-05] & [H-03] - Hyperliquid Bridge Address Updated from 0x22222 -> Token Specific System Addresses

### DIFF
--- a/src/vaults/hyperliquid/interfaces/IVaultEscrow.sol
+++ b/src/vaults/hyperliquid/interfaces/IVaultEscrow.sol
@@ -62,4 +62,12 @@ interface IVaultEscrow {
 
     /// @notice Returns the vault equity that is controlled by the escrow contract
     function vaultEquity() external view returns (uint256);
+
+    /**
+     * @notice Returns the address of the asset system
+     * @dev The system address is used to bridge assets to Hyperliquid L1.
+     *      The system address for an asset is derived by appending `0x20` followed by all 0s,
+     *      and then the asset index encoded in big-endian format.
+     */
+    function assetSystemAddr() external view returns (address);
 }

--- a/test/hyperliquid/VaultSetupUnit.t.sol
+++ b/test/hyperliquid/VaultSetupUnit.t.sol
@@ -176,6 +176,38 @@ contract VaultSetupUnitTest is Test {
         assertEq(vault.redeemEscrowIndex(), 1);
     }
 
+    function test_AssetSystemAddr() public {
+        /// System address for asset index 0
+        address implementation = address(new HyperEvmVault(l1Vault));
+        vault = HyperEvmVault(
+            address(
+                new ERC1967Proxy(
+                    implementation,
+                    abi.encodeWithSelector(
+                        HyperEvmVault.initialize.selector, "Wrapped HLP", "wHLP", address(asset), 0, 8, 10e8, 7, owner
+                    )
+                )
+            )
+        );
+        VaultEscrow escrow = VaultEscrow(vault.escrows(vault.depositEscrowIndex()));
+        assertEq(escrow.assetSystemAddr(), address(0x2000000000000000000000000000000000000000));
+
+        /// System address for asset index  200
+        implementation = address(new HyperEvmVault(l1Vault));
+        vault = HyperEvmVault(
+            address(
+                new ERC1967Proxy(
+                    implementation,
+                    abi.encodeWithSelector(
+                        HyperEvmVault.initialize.selector, "Wrapped HLP", "wHLP", address(asset), 200, 8, 10e8, 7, owner
+                    )
+                )
+            )
+        );
+        escrow = VaultEscrow(vault.escrows(vault.depositEscrowIndex()));
+        assertEq(escrow.assetSystemAddr(), address(0x20000000000000000000000000000000000000C8));
+    }
+
     function _updateL1BlockNumber(uint64 blockNumber_) internal {
         vm.store(L1_BLOCK_NUMBER_PRECOMPILE_ADDRESS, bytes32(uint256(0)), bytes32(uint256(blockNumber_)));
     }

--- a/test/hyperliquid/VaultUnit.t.sol
+++ b/test/hyperliquid/VaultUnit.t.sol
@@ -33,7 +33,7 @@ contract VaultUnitTest is Test {
 
     address public constant VAULT_EQUITY_PRECOMPILE_ADDRESS = 0x0000000000000000000000000000000000000802;
     address public constant WRITE_PRECOMPILE_ADDRESS = 0x3333333333333333333333333333333333333333;
-    address public constant HYPERLIQUID_SPOT_BRIDGE = 0x2222222222222222222222222222222222222222;
+    address public constant USDC_SYSTEM_ADDRESS = 0x2000000000000000000000000000000000000000;
 
     function setUp() public {
         // Set up precompiles
@@ -83,7 +83,7 @@ contract VaultUnitTest is Test {
 
         assertEq(asset.balanceOf(address(escrow)), 0);
         assertEq(asset.balanceOf(address(wrapper)), 0);
-        assertEq(asset.balanceOf(HYPERLIQUID_SPOT_BRIDGE), amount);
+        assertEq(asset.balanceOf(USDC_SYSTEM_ADDRESS), amount);
     }
 
     function test_mint() public {
@@ -111,7 +111,7 @@ contract VaultUnitTest is Test {
 
         assertEq(asset.balanceOf(address(escrow)), 0);
         assertEq(asset.balanceOf(address(wrapper)), 0);
-        assertEq(asset.balanceOf(HYPERLIQUID_SPOT_BRIDGE), amount * 2);
+        assertEq(asset.balanceOf(0x2000000000000000000000000000000000000000), amount * 2);
     }
 
     function deposit_multiBlock() public {
@@ -226,8 +226,8 @@ contract VaultUnitTest is Test {
         assertEq(bobRequest.assets, 14776505356);
 
         /// Update escrow and vault state to reflect precompile calls
-        vm.startPrank(HYPERLIQUID_SPOT_BRIDGE);
-        asset.mint(HYPERLIQUID_SPOT_BRIDGE, 97.5e8);
+        vm.startPrank(USDC_SYSTEM_ADDRESS);
+        asset.mint(USDC_SYSTEM_ADDRESS, 97.5e8);
         /// MINT REMAINDER OF TOKENS TO BRIDGE
         asset.transfer(address(escrow), 297.5e8); // 295.5e8
 


### PR DESCRIPTION
In a recent breaking change from Hyperliquid each token on Hyperliquid Core received their own bridging address instead of the original shared system address of `0x2222222222222222222222222222222222222222`. This update broke the existing logic of the `VaultEscrow` contract.

This PR fixes this by programmatically calculating the bridge address / specific contract for a specific asset index.

We can optimize this further by calculating this within the constructor instead of every call, but we will update this in a later PR when we migrate the `VaultEscrow` from a regular contract to an upgradeable contract following the Beacon Pattern.