### PR TITLE
[H-08] User Can Drain Escrow Equity by Executing Approved Withdrawals

### DIFF
--- a/src/vaults/hyperliquid/HyperEvmVault.sol
+++ b/src/vaults/hyperliquid/HyperEvmVault.sol
@@ -256,14 +256,14 @@ contract HyperEvmVault is IHyperEvmVault, ERC4626Upgradeable, Ownable2StepUpgrad
         internal
         override
     {
-        _beforeWithdraw(assets_, shares_);
+        _beforeWithdraw(owner, assets_, shares_);
         super._withdraw(caller, receiver, owner, assets_, shares_);
     }
 
     /// @notice Updates the redeem requests & retrieves assets from the escrow contracts
-    function _beforeWithdraw(uint256 assets_, uint256 shares_) internal {
+    function _beforeWithdraw(address owner, uint256 assets_, uint256 shares_) internal {
         V1Storage storage $ = _getV1Storage();
-        RedeemRequest storage request = $.redeemRequests[msg.sender];
+        RedeemRequest storage request = $.redeemRequests[owner];
         require(request.assets >= assets_, Errors.WITHDRAW_TOO_LARGE());
         require(request.shares >= shares_, Errors.WITHDRAW_TOO_LARGE());
 


### PR DESCRIPTION
Due to `ERC4626` approvals in allowing users to withdraw funds on behalf of another user, a malicious user can create 2 separate addresses make a grant 1 address max approval and siphon off funds by keeping one addresses request full and withdraw others funds that have been requested to be withdrawn.

This PR fixes this issue by passing `owner` as an argument instead of `msg.sender` to prevent unauthorized withdrawls on behalf of another user.