### PR TITLE
[L-09] currentBlockDeposits function may return an incorrect value

### DIFF
--- a/src/vaults/hyperliquid/HyperEvmVault.sol
+++ b/src/vaults/hyperliquid/HyperEvmVault.sol
@@ -554,7 +554,7 @@ contract HyperEvmVault is IHyperEvmVault, ERC4626Upgradeable, Ownable2StepUpgrad
     }
 
     /// @inheritdoc IHyperEvmVault
-    function currentBlockDeposits() external view override returns (uint64) {
+    function currentL1BlockDeposits() external view override returns (uint64) {
        return _getV1Storage().lastL1Block == l1Block() ? _getV1Storage().currentBlockDeposits : 0;
     }
 

--- a/src/vaults/hyperliquid/interfaces/IHyperEvmVault.sol
+++ b/src/vaults/hyperliquid/interfaces/IHyperEvmVault.sol
@@ -98,8 +98,8 @@ interface IHyperEvmVault is IERC4626 {
     /// @notice Returns the last L1 block number noticed by the vault
     function lastL1Block() external view returns (uint64);
 
-    /// @notice Returns the current amount of assets that have been deposited during the last L1 block noticed by the vault
-    function currentBlockDeposits() external view returns (uint64);
+    /// @notice Returns the current amount of assets that have been deposited during the current L1 block
+    function currentL1BlockDeposits() external view returns (uint64);
 
     /// @notice Returns the last time fees were collected from the vault and shares were minted to the feeRecipient
     function lastFeeCollectionTimestamp() external view returns (uint64);

--- a/test/hyperliquid/VaultUnit.t.sol
+++ b/test/hyperliquid/VaultUnit.t.sol
@@ -126,7 +126,7 @@ contract VaultUnitTest is Test {
         _updateL1BlockNumber(2);
         wrapper.deposit(amount, alice);
 
-        assertEq(wrapper.currentBlockDeposits(), amount);
+        assertEq(wrapper.currentL1BlockDeposits(), amount);
         assertEq(wrapper.lastL1Block(), 1);
         assertEq(wrapper.totalAssets(), amount * 2);
         assertEq(wrapper.totalSupply(), amount * 2);


### PR DESCRIPTION
This PR updates the purpose, name and functionality to match the suggestions in [L-09].