### PR TITLE
[M-02] HyperEvmVault: Wrong rounding direction in mint function

### DIFF
--- a/src/vaults/hyperliquid/HyperEvmVault.sol
+++ b/src/vaults/hyperliquid/HyperEvmVault.sol
@@ -463,7 +463,7 @@ contract HyperEvmVault is IHyperEvmVault, ERC4626Upgradeable, Ownable2StepUpgrad
     }
 
     function _convertToShares(uint256 assets, Math.Rounding /*rounding*/ ) internal view override returns (uint256) {
-        return assets.mulDivUp(totalSupply(), tvl());
+        return assets.mulDivDown(totalSupply(), tvl());
     }
 
     function _convertToAssets(uint256 shares, Math.Rounding /*rounding*/ ) internal view override returns (uint256) {


### PR DESCRIPTION
This PR fixes the rounding issue within the rounding within the `mint` function.