### PR TITLE
[H-01] Pending redeem/withdraw requests are not deducted from total assets and total shares

### DIFF
--- a/src/vaults/hyperliquid/interfaces/IHyperEvmVault.sol
+++ b/src/vaults/hyperliquid/interfaces/IHyperEvmVault.sol
@@ -22,6 +22,16 @@ interface IHyperEvmVault is IERC4626 {
         uint256 shares;
     }
 
+    /**
+     * @notice A struct that contains the sum of all the assets and shares that are currently being requested to redeem
+     * @param assets The sum of all the assets that are currently being requested to redeem
+     * @param shares The sum of all the shares that are currently being requested to redeem
+     */
+    struct RequestSum {
+        uint64 assets;
+        uint256 shares;
+    }
+
     /*//////////////////////////////////////////////////////////////
                                 Events
     //////////////////////////////////////////////////////////////*/
@@ -94,6 +104,9 @@ interface IHyperEvmVault is IERC4626 {
 
     /// @notice Returns the redeem request for a given user
     function redeemRequests(address user) external view returns (RedeemRequest memory);
+
+    /// @notice Returns the sum of all the assets and shares that are currently being requested to redeem
+    function requestSum() external view returns (RequestSum memory);
 
     /// @notice Returns the last L1 block number noticed by the vault
     function lastL1Block() external view returns (uint64);


### PR DESCRIPTION
This PR introduces a fix to mitigate the share price discrepancy that exists due to the async redemption model. In order to have a more accurate share price calculation this change adds the `requestSum` storage variable which tracks the total amount of shares and assets currently being processed for redemption. This struct is used to decrement both `_totalEscrowValue` and `totalSupply` to ensure that users share price is not negatively affected by redemption requests.