### PR TITLE
[M-02] Incorrect max withdrawable assets amount causes unexpected revert

### DIFF
--- a/src/vaults/hyperliquid/HyperEvmVault.sol
+++ b/src/vaults/hyperliquid/HyperEvmVault.sol
@@ -209,7 +209,13 @@ contract HyperEvmVault is IHyperEvmVault, ERC4626Upgradeable, Ownable2StepUpgrad
     function maxWithdrawableAssets() public view returns (uint256) {
         V1Storage storage $ = _getV1Storage();
         VaultEscrow escrowToRedeem = VaultEscrow($.escrows[redeemEscrowIndex()]);
-        return escrowToRedeem.vaultEquity();
+        VaultEscrow.L1WithdrawState memory withdrawState = escrowToRedeem.l1WithdrawState();
+
+        uint256 vaultEquity = escrowToRedeem.vaultEquity();
+        if (withdrawState.lastWithdrawBlock == l1Block()) {
+            vaultEquity -= withdrawState.lastWithdraws;
+        }
+        return vaultEquity;
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
`maxWithdrawableAssets` doesnt account for assets being withdrawn but not landed. To fix this we simply check if the current l1block matches the last withdrawn block and deduct the requested amount.