### PR TITLE
[H-01] Flawed withdrawal logic when caller differs from share owner

### DIFF
--- a/src/helpers/BlueberryErrors.sol
+++ b/src/helpers/BlueberryErrors.sol
@@ -64,4 +64,7 @@ library BlueberryErrors {
 
     /// @notice Error thrown when the escrow is invalid and the assets do not match
     error INVALID_ESCROW();
+
+    /// @notice Error thrown when someone other than the owner tries to call redeem or withdraw
+    error OnlyOwnerCanWithdraw();
 }

--- a/src/vaults/hyperliquid/HyperEvmVault.sol
+++ b/src/vaults/hyperliquid/HyperEvmVault.sol
@@ -300,6 +300,7 @@ contract HyperEvmVault is IHyperEvmVault, ERC4626Upgradeable, Ownable2StepUpgrad
         internal
         override
     {
+        require(caller == owner, Errors.OnlyOwnerCanWithdraw());
         _beforeWithdraw(owner, assets_, shares_);
         super._withdraw(caller, receiver, owner, assets_, shares_);
     }


### PR DESCRIPTION
This PR mitigates H-01 by only allowing the owner of a position to withdraw/redeem funds. This does not hinder UX as this is how redemption requests work, so just keeps processes consistent around the codebase.