### PR TITLE
L[08] & L[10] - WrappedVaultShare constructor Fixes

### DIFF
--- a/script/DeployRouterTestnet.s.sol
+++ b/script/DeployRouterTestnet.s.sol
@@ -88,9 +88,6 @@ contract DeployRouterTestnet is Script {
 
         //ERC20(PURR).approve(address(router), type(uint256).max);
 
-        // 5. Set minter permissions on router
-        shareToken.grantRole(shareToken.MINTER_ROLE(), address(router));
-
         console.log("Router Proxy deployed at", address(router));
 
         console.log("Escrow 0", address(router.escrows(0)));

--- a/src/vaults/hyperliquid/WrappedVaultShare.sol
+++ b/src/vaults/hyperliquid/WrappedVaultShare.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import {BlueberryErrors as Errors} from "@blueberry-v2/helpers/BlueberryErrors.sol";
 
 import {MintableToken} from "@blueberry-v2/utils/MintableToken.sol";
+import {BlueberryErrors as Errors} from "@blueberry-v2/helpers/BlueberryErrors.sol";
 import {HyperliquidEscrow} from "@blueberry-v2/vaults/hyperliquid/HyperliquidEscrow.sol";
 import {HyperVaultRouter} from "@blueberry-v2/vaults/hyperliquid/HyperVaultRouter.sol";
 
@@ -22,7 +23,13 @@ contract WrappedVaultShare is MintableToken {
     constructor(string memory name, string memory symbol, address router, address admin)
         MintableToken(name, symbol, 18, admin)
     {
-        router = ROUTER;
+        require(router != address(0), Errors.ADDRESS_ZERO());
+        ROUTER = router;
+
+        // Grant the minter and burner roles to the router so it can
+        //     mint and burn share tokens during deposits and redemptions
+        _grantRole(MINTER_ROLE, router);
+        _grantRole(BURNER_ROLE, router);
     }
 
     /// @notice Calls the pokeFees functions on the router contract before any transfer

--- a/test/hyperliquid/WrappedVaultShare.t.sol
+++ b/test/hyperliquid/WrappedVaultShare.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/test.sol";
+import {WrappedVaultShare} from "@blueberry-v2/vaults/hyperliquid/WrappedVaultShare.sol";
+
+contract MockRouter {
+    uint256 public pokeCount;
+
+    function pokeFees() external {
+        pokeCount++;
+    }
+}
+
+contract WrappedVaultShareTest is Test {
+    WrappedVaultShare public wHlp;
+    MockRouter public router;
+
+    // EOAs
+    address admin = makeAddr("admin");
+    address recipient = makeAddr("recipient");
+    address rando = makeAddr("rando");
+
+    function setUp() public virtual {
+        router = new MockRouter();
+        wHlp = new WrappedVaultShare("Wrapped HLP", "wHLP", address(router), admin);
+    }
+
+    function test_Constructor() public view {
+        assertEq(wHlp.name(), "Wrapped HLP");
+        assertEq(wHlp.symbol(), "wHLP");
+        assertEq(wHlp.decimals(), 18);
+        assertEq(wHlp.ROUTER(), address(router));
+    }
+
+    function test_AdminCannotMint() public {
+        vm.startPrank(admin);
+        vm.expectRevert();
+        wHlp.mint(recipient, 100e18);
+        vm.stopPrank();
+    }
+
+    function test_PokeFeesCalledOnTransfer() public {
+        vm.startPrank(address(router));
+        wHlp.mint(recipient, 100e18);
+        vm.stopPrank();
+
+        uint256 count = router.pokeCount();
+        vm.startPrank(recipient);
+        wHlp.transfer(rando, 10e18);
+        assertEq(router.pokeCount(), count + 1);
+    }
+
+    function test_RouterCanMint() public {
+        vm.startPrank(address(router));
+        wHlp.mint(recipient, 100e18);
+        assertEq(wHlp.balanceOf(recipient), 100e18);
+        vm.stopPrank();
+    }
+
+    function test_RouterCanBurn() public {
+        vm.startPrank(recipient);
+        wHlp.approve(address(router), 100e18);
+
+        vm.startPrank(address(router));
+        wHlp.mint(recipient, 100e18);
+        wHlp.burnFrom(recipient, 100e18);
+        assertEq(wHlp.balanceOf(recipient), 0);
+    }
+}


### PR DESCRIPTION
# Overview
This PR addresses 2 issues in the most recent audit report.

## Issues

**1. L-08:** BURNER_ROLE not assigned in deployment script
BURNER_ROLE not assigned in deployment script

**2. L-10:** WrappedVaultShare constructor misassigns ROUTER

## Resolution

For the first issue we now initialize the BURNER_ROLE and MINTER_ROLE within `WrappedVaultShare` constructor & for the second issue we swap the order of the statement.

## Testing
Testing has been added for all features within the `WrappedVaultShare` contract.