### PR TITLE
[M-01] _validateSpotMarket incorrectly validates spot market

### DIFF
--- a/src/vaults/hyperliquid/HyperVaultRouter.sol
+++ b/src/vaults/hyperliquid/HyperVaultRouter.sol
@@ -433,12 +433,10 @@ contract HyperVaultRouter is IHyperVaultRouter, Ownable2StepUpgradeable, Reentra
         require(success, Errors.PRECOMPILE_CALL_FAILED());
         SpotInfo memory spotInfo = abi.decode(result, (SpotInfo));
 
-        for (uint256 i = 0; i < 2; i++) {
-            if (spotInfo.tokens[i] == USDC_SPOT_INDEX || spotInfo.tokens[i] == assetIndex_) {
-                return true;
-            }
-        }
-        return false;
+        return (
+            (spotInfo.tokens[0] == assetIndex_ && spotInfo.tokens[1] == USDC_SPOT_INDEX)
+                || (spotInfo.tokens[1] == assetIndex_ && spotInfo.tokens[0] == USDC_SPOT_INDEX)
+        );
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR fixes the flawed validation logic within `_validateSpotMarket` function to make sure that both token indexes are checked.