### PR TITLE
USDC Specific logic

### DIFF
--- a/src/vaults/hyperliquid/HyperVaultRouter.sol
+++ b/src/vaults/hyperliquid/HyperVaultRouter.sol
@@ -140,7 +140,8 @@ contract HyperVaultRouter is IHyperVaultRouter, Ownable2StepUpgradeable, Reentra
 
         // Get the USD value of the asset to properly calculate shares to mint
         uint256 scaler = 10 ** (18 - details.evmDecimals);
-        uint256 rate = (assetIndex_ == USDC_EVM_SPOT_INDEX) ? 1e18 : escrow.getRate(details.spotMarket);
+        uint256 rate =
+            (assetIndex_ == USDC_EVM_SPOT_INDEX) ? 1e18 : escrow.getRate(details.spotMarket, details.szDecimals);
         uint256 usdValue = rate.mulWadDown(amount * scaler);
         require(usdValue >= $.minDepositValue, Errors.MIN_DEPOSIT_AMOUNT());
 
@@ -178,7 +179,8 @@ contract HyperVaultRouter is IHyperVaultRouter, Ownable2StepUpgradeable, Reentra
         // Convert the USD amount to withdraw to the withdraw asset amount
         HyperliquidEscrow escrow = HyperliquidEscrow($.escrows[depositEscrowIndex()]);
 
-        uint256 rate = (assetIndex_ == USDC_EVM_SPOT_INDEX) ? 1e18 : escrow.getRate(details.spotMarket);
+        uint256 rate =
+            (assetIndex_ == USDC_EVM_SPOT_INDEX) ? 1e18 : escrow.getRate(details.spotMarket, details.szDecimals);
         amount = rate.mulWadDown(usdAmount);
         uint256 scaler = 10 ** (18 - details.evmDecimals);
         amount = amount / scaler;

--- a/src/vaults/hyperliquid/HyperliquidEscrow.sol
+++ b/src/vaults/hyperliquid/HyperliquidEscrow.sol
@@ -103,7 +103,7 @@ contract HyperliquidEscrow is IHyperliquidEscrow, L1EscrowActions {
                 // If the asset is USDC we only need to get the contract balance since we already queried the spot balance
                 tvl_ += IERC20(assetAddr).balanceOf(address(this)) * evmScaling;
             } else {
-                uint256 rate = getRate(details.spotMarket);
+                uint256 rate = getRate(details.spotMarket, details.szDecimals);
                 uint256 balance = IERC20(assetAddr).balanceOf(address(this)) * evmScaling;
                 balance += _spotAssetBalance(uint64(assetIndex));
                 tvl_ += balance.mulWadDown(rate);
@@ -137,10 +137,10 @@ contract HyperliquidEscrow is IHyperliquidEscrow, L1EscrowActions {
     }
 
     /// @inheritdoc IHyperliquidEscrow
-    function getRate(uint32 spotMarket) public view override returns (uint256) {
+    function getRate(uint32 spotMarket, uint8 szDecimals) public view override returns (uint256) {
         (bool success, bytes memory result) = SPOT_PX_PRECOMPILE_ADDRESS.staticcall(abi.encode(spotMarket));
         require(success, Errors.PRECOMPILE_CALL_FAILED());
-        uint256 scaledRate = uint256(abi.decode(result, (uint64))) * USDC_SPOT_SCALING;
+        uint256 scaledRate = uint256(abi.decode(result, (uint64))) * USDC_SPOT_SCALING * (10 ** szDecimals);
         return scaledRate;
     }
 

--- a/src/vaults/hyperliquid/interfaces/IHyperliquidEscrow.sol
+++ b/src/vaults/hyperliquid/interfaces/IHyperliquidEscrow.sol
@@ -73,9 +73,10 @@ interface IHyperliquidEscrow is IHyperliquidCommon {
     /**
      * @notice Returns the exchange rate of a token in USD
      * @param spotMarket The Spot Market index of a token
+     * @param szDecimals The number of decimals that spot prices are returned with
      * @return The exchange rate in USD with 18 decimals
      */
-    function getRate(uint32 spotMarket) external view returns (uint256);
+    function getRate(uint32 spotMarket, uint8 szDecimals) external view returns (uint256);
 
     // /**
     //  * @notice The L1 address of the vault


### PR DESCRIPTION
This PR adds USDC specific logic in order to prevent various issues that emerge from index conflicts.

The following issues are fixed from this PR:

**[C-02]:** Missing asset index check allows any token to mint shares
**[H-02]:** Missing custom logic for USDC spot market
**[L-01]:** Unsupported asset can be set in withdraw asset by index collision

## NOTICE
Accidentally also pushed the `szDecimal` scaling fix for `getRate`
Commit: https://github.com/Blueberryfi/blueberry-v2-contracts/pull/31/commits/289307e85222af1c59a628aea19c29d789baa41e

**[H-01]:** getRate() ignores szDecimals

