### PR TITLE
[L-09] Dead code in bridgeToL1

### DIFF
--- a/src/vaults/hyperliquid/L1EscrowActions.sol
+++ b/src/vaults/hyperliquid/L1EscrowActions.sol
@@ -99,7 +99,7 @@ abstract contract L1EscrowActions is EscrowAssetStorage, AccessControlUpgradeabl
         AssetDetails memory details = $.assetDetails[assetIndex];
         require(details.evmContract != address(0), Errors.ADDRESS_ZERO());
 
-        // Sanitize the amount to the correct spot decimals so åthat we dont lose small amounts in the
+        // Sanitize the amount to the correct spot decimals so that we dont lose small amounts in the
         //     bridging process.
         uint256 factor =
             (details.evmDecimals > details.weiDecimals) ? 10 ** (details.evmDecimals - details.weiDecimals) : 1;


### PR DESCRIPTION
There is dead code within the `bridgeToL1` function since you can only bridge once per EVM block. This PR removes such deadcode and always updates `inFlightBridge` values for an asset.