### PR TITLE
[L-05] maxRedeemable Underestimates Available Shares Due to Uncollected Fees

### DIFF
--- a/src/vaults/hyperliquid/HyperVaultRouter.sol
+++ b/src/vaults/hyperliquid/HyperVaultRouter.sol
@@ -516,7 +516,11 @@ contract HyperVaultRouter is IHyperVaultRouter, Ownable2StepUpgradeable, Reentra
 
         // Calculate the max redeemable amount based on the USD value of the withdraw asset
         uint256 usdValue = maxWithdraw.mulWadDown(rate * scaler);
-        return usdValue.mulDivDown(_shareSupply(), tvl());
+        uint256 tvl_ = tvl();
+        if (tvl_ == 0) return 0;
+
+        uint256 feeShares = _previewFeeShares($, tvl_);
+        return usdValue.mulDivDown(_shareSupply() + feeShares, tvl_);
     }
 
     /// @inheritdoc IHyperVaultRouter


### PR DESCRIPTION
This PR adds the potential fees generated from a redemption within the calculation of `maxRedeemable`.