### PR TITLE
TradeV2 | Trade execution at spot price

### DIFF
--- a/src/vaults/hyperliquid/HyperliquidEscrow.sol
+++ b/src/vaults/hyperliquid/HyperliquidEscrow.sol
@@ -151,10 +151,7 @@ contract HyperliquidEscrow is IHyperliquidEscrow, L1EscrowActions {
 
     /// @inheritdoc IHyperliquidEscrow
     function getRate(uint32 spotMarket, uint8 szDecimals) public view override returns (uint256) {
-        (bool success, bytes memory result) = SPOT_PX_PRECOMPILE_ADDRESS.staticcall(abi.encode(spotMarket));
-        require(success, Errors.PRECOMPILE_CALL_FAILED());
-        uint256 scaledRate = uint256(abi.decode(result, (uint64))) * USDC_SPOT_SCALING * (10 ** szDecimals);
-        return scaledRate;
+        return _spotPrice(spotMarket) * USDC_SPOT_SCALING * (10 ** szDecimals);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -200,5 +197,17 @@ contract HyperliquidEscrow is IHyperliquidEscrow, L1EscrowActions {
      */
     function _scaleToSpotDecimals(uint64 amount_) internal pure returns (uint64) {
         return uint64(amount_ * (10 ** (USDC_SPOT_DECIMALS - USDC_PERP_DECIMALS)));
+    }
+
+    /**
+     * @notice Returns the raw spot price for a given market index.  Overrides the virtual
+     * @dev price in terms of the quote asset (USDC in the case of these vaults)
+     * @param spotMarket The index of the spot market
+     * @return price Raw spot price of the asset
+     */
+    function _spotPrice(uint32 spotMarket) internal view override returns (uint64 price) {
+        (bool success, bytes memory result) = SPOT_PX_PRECOMPILE_ADDRESS.staticcall(abi.encode(spotMarket));
+        require(success, Errors.PRECOMPILE_CALL_FAILED());
+        price = abi.decode(result, (uint64));
     }
 }

--- a/src/vaults/hyperliquid/L1EscrowActions.sol
+++ b/src/vaults/hyperliquid/L1EscrowActions.sol
@@ -182,23 +182,41 @@ abstract contract L1EscrowActions is EscrowAssetStorage, AccessControlUpgradeabl
 
     /**
      * @notice Executes an IOC order on the L1
-     * @dev No balance/price validation is necessary since we track the balances of all account types to calculate tvl,
-     *      so any failures can simply be retried with different parameters.
+     * @dev This function has been deprecated in favor of the `tradeV2` function which
+     *      allows for safer trading with limit orders.
+     */
+    function trade(uint32, /*assetIndex*/ bool, /*isBuy*/ uint64, /*limitPx*/ uint64, /*sz*/ uint8 /*tif*/ )
+        external
+        onlyRole(LIQUIDITY_ADMIN_ROLE)
+        singleActionBlock
+    {
+        revert("DEPRECATED: use tradeV2");
+    }
+
+    /**
+     * @notice Executes an IOC order on the L1
+     * @dev The price of the trade is set based on the current spot price of the asset.
      * @param assetIndex The index of the asset to trade
      * @param isBuy Whether to buy or sell
-     * @param limitPx The limit price
      * @param sz The size of the trade
      * @param tif The time in force for the order, 1 = Alo, 2 = Gtc, 3 = IOC
      */
-    function trade(uint32 assetIndex, bool isBuy, uint64 limitPx, uint64 sz, uint8 tif)
+    function tradeV2(uint32 assetIndex, bool isBuy, uint64 sz, uint8 tif)
         external
         onlyRole(LIQUIDITY_ADMIN_ROLE)
         singleActionBlock
     {
         V1AssetStorage storage $ = _getV1AssetStorage();
         require($.supportedAssets.contains(assetIndex), Errors.COLLATERAL_NOT_SUPPORTED());
-        uint32 iocIndex = SPOT_MARKET_INDEX_OFFSET + $.assetDetails[assetIndex].spotMarket;
-        _limitOrder(iocIndex, isBuy, limitPx, sz, tif);
+
+        AssetDetails memory details = $.assetDetails[assetIndex];
+        uint32 spotMarketIndex = details.spotMarket;
+        uint64 spotPrice = _spotPrice(spotMarketIndex) * uint64(10 ** details.szDecimals);
+        uint32 iocIndex = SPOT_MARKET_INDEX_OFFSET + spotMarketIndex;
+
+        require(spotPrice != 0, "PRICE_ZERO());");
+
+        _limitOrder(iocIndex, isBuy, spotPrice, sz, tif);
     }
 
     /**
@@ -364,4 +382,13 @@ abstract contract L1EscrowActions is EscrowAssetStorage, AccessControlUpgradeabl
         uint160 base = uint160(0x2000000000000000000000000000000000000000);
         return address(base | uint160(token));
     }
+
+    /**
+     * @notice Returns the raw spot price for a given market index.
+     * @dev price in terms of the quote asset (USDC in the case of these vaults)
+     * @dev Implementation of this function is provided in HyperliquidEscrow.sol
+     * @param spotMarket The index of the spot market
+     * @return price Raw spot price of the asset
+     */
+    function _spotPrice(uint32 spotMarket) internal view virtual returns (uint64 price);
 }


### PR DESCRIPTION
# Overview
In order to increase the decentralization and reduce failure points within `bbHLP`. `HyperliquidEscrow::trade` has been deprecated in favor of `HyperliquidEscrow::tradeV2` which now removes `limitPx` as an input parameter, allowing for trades to be placed at the price set by Hyperliquid's `spotPx` oracle.

## `spotPx`
The `spotPx` oracle is a safer mean of setting trade execution price as its more resistent to manipulation or error due to utilizing multiple sources to derive price. 

Per the Hyperliquid docs, "The spot oracle prices are computed by each validator as the weighted median of Binance, OKX, Bybit, Kraken, Kucoin, Gate IO, MEXC, and Hyperliquid spot prices for each asset, with weights 3, 2, 2, 1, 1, 1, 1, 1 respectively"

For more information on Hyperliquid Oracles see: https://hyperliquid.gitbook.io/hyperliquid-docs/hypercore/oracle